### PR TITLE
Add download functionality directly from Azure via SAS token URL

### DIFF
--- a/plugins/azure-storage-backend/src/service/AzureStorageBuilder.ts
+++ b/plugins/azure-storage-backend/src/service/AzureStorageBuilder.ts
@@ -103,6 +103,21 @@ export class AzureStorageBuilder {
       },
     );
 
+    router.get(
+      '/:storageAccount/containers/:containerName/:blobName/getDownloadLink',
+      async (request, response) => {
+        const { storageAccount, containerName, blobName } = request.params;
+        const prefix = request.query.prefix;
+        const url = await azureStorageProvider.getDownloadLink(
+          storageAccount,
+          containerName,
+          blobName,
+          prefix,
+        );
+        response.json({ url });
+      },
+    );
+
     router.use(errorHandler());
 
     return router;

--- a/plugins/azure-storage/src/api/AzureStorageApi.ts
+++ b/plugins/azure-storage/src/api/AzureStorageApi.ts
@@ -20,4 +20,16 @@ export interface AzureStorageApi {
     contentType: string,
     prefix?: string,
   ): Promise<any>;
+  getDownloadLink(
+    storageAccount: string,
+    containerName: string,
+    blobName: string,
+    prefix?: string,
+  ): Promise<any>;
+  downloadBlobDirectly(
+    storageAccount: string,
+    containerName: string,
+    blobName: string,
+    prefix?: string,
+  ): Promise<any>;
 }

--- a/plugins/azure-storage/src/components/AzureStoragePage/AzureStorageContent.tsx
+++ b/plugins/azure-storage/src/components/AzureStoragePage/AzureStorageContent.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { Typography, Grid, makeStyles } from '@material-ui/core';
 import SubdirectoryArrowLeftIcon from '@material-ui/icons/SubdirectoryArrowLeft';
 import GetAppIcon from '@material-ui/icons/GetApp';
+import CloudDownloadIcon from '@material-ui/icons/CloudDownload';
 import {
   Content,
   EmptyState,
@@ -125,6 +126,14 @@ export const AzureStorageContent = () => {
       folderStack.join(),
     );
   };
+  const downloadBlobDirectly = async (blobName: string) => {
+    azureStorageApi.downloadBlob(
+      accountName,
+      containerName,
+      blobName,
+      folderStack.join(),
+    );
+  };
 
   const { value, loading, error } = useAsync(async () => {
     const data: string[] = await azureStorageApi.listStorageAccounts();
@@ -189,10 +198,21 @@ export const AzureStorageContent = () => {
               rowData => {
                 return {
                   icon: () => <GetAppIcon />,
-                  tooltip: 'Download',
+                  tooltip: 'Download From Backend',
                   isFreeAction: false,
                   onClick: () => {
                     downloadBlob(rowData.filename, rowData.contentType);
+                  },
+                  hidden: rowData.contentType === 'Folder' ? true : false,
+                };
+              },
+              rowData => {
+                return {
+                  icon: () => <CloudDownloadIcon />,
+                  tooltip: 'Download From Azure',
+                  isFreeAction: false,
+                  onClick: () => {
+                    downloadBlobDirectly(rowData.filename);
                   },
                   hidden: rowData.contentType === 'Folder' ? true : false,
                 };


### PR DESCRIPTION
Added button in front end to download with sas token.

My original requirement is for another front end plugin that want to levarage direct blob storage download of known URIs for acc/container/prefix/blob.

I added functionality to backend (when supported by the type of credentials for the respective storage accounts) to generate a 15 minute SAS token for a direct download by the client without authentication.

I am thinking that this could be opt in via configuration for one or more download types per storage account instead of always being available for each account that supports either. We could also make the life time of the SAS token configurable there.

I changed the tooltip for the existing download button to reflect that its via the backend where as the other is via SAS token.